### PR TITLE
Try using Passport's environment variable keys first.

### DIFF
--- a/src/KeyRepository.php
+++ b/src/KeyRepository.php
@@ -8,23 +8,25 @@ use Laravel\Passport\Passport;
 
 class KeyRepository
 {
-    public function getPrivateKey()
+    public function getPrivateKey(): CryptKey
     {
-        return new CryptKey('file://' . Passport::keyPath('oauth-private.key'));
+        $privateKey = config('passport.private_key')
+            ?? 'file://' . Passport::keyPath('oauth-private.key');
+        return new CryptKey($privateKey);
     }
 
-    public function getPublicKey()
+    public function getPublicKey(): CryptKey
     {
-        return new CryptKey(
-            'file://' . Passport::keyPath('oauth-public.key')
-        );
+        $publicKey = config('passport.public_key')
+            ?? 'file://' . Passport::keyPath('oauth-public.key');
+        return new CryptKey($publicKey);
     }
 
-    public function getPublicKeyForClient(Client $client, $kid = null)
+    public function getPublicKeyForClient(Client $client, $kid = null): CryptKey
     {
-        return new CryptKey(
-            file_get_contents('file://' . Passport::keyPath('oauth-public.key'))
-        );
+        $publicKey = config('passport.public_key')
+            ?? file_get_contents('file://' . Passport::keyPath('oauth-public.key'));
+        return new CryptKey($publicKey);
     }
 
     public function getAllPublicKeys()
@@ -32,7 +34,7 @@ class KeyRepository
         return [$this->getPublicKey()];
     }
 
-    public function getPrivateKeyByKid($kid)
+    public function getPrivateKeyByKid($kid): CryptKey
     {
         return $this->getPrivateKey();
     }


### PR DESCRIPTION
This change adds stronger type checking and also support for Passport's environment variable public/private keys, however, this will ignore key files if environment variable keys exist. This is probably ok as the presence of the environment variables acts as a de facto flag.

I was unable to get a working Docker environment up to modify tests, but I used these changes locally and they worked for me.

One note, I don't see any difference between `getPublicKey()` and `getPublicKeyForClient()` except that the latter passes the full key to the `CryptoKey` constructor, where the former just passes the path. Why not just make one an alias instead?