### PR TITLE
OIDC Provider Configuration Response MUST return a JSON object

### DIFF
--- a/src/Model/Provider.php
+++ b/src/Model/Provider.php
@@ -79,8 +79,6 @@ class Provider implements ProviderInterface
 
     public function toJson($options = 0)
     {
-        return json_encode([
-            $this->wellKnown
-        ], $options);
+        return json_encode($this->wellKnown, $options);
     }
 }


### PR DESCRIPTION
Currently the URL `.well-known/openid-configuration` returns a JSON array, not a JSON object. This is acceptable if returning multiple configurations, but the laravel-openid-connect-server is currently designed to only return a single configuration object. Thus, the single object return should not be wrapped in a JSON array.

According to the [OIDC 1.0 Discovery specification](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationResponse):

> Section 4.2.  OpenID Provider Configuration Response
> 
> The response is a set of Claims about the OpenID Provider's configuration, including all necessary endpoints and public key location information. A successful response MUST use the 200 OK HTTP status code and return a JSON object using the application/json content type that contains a set of Claims as its members that are a subset of the Metadata values defined in Section 3. Other Claims MAY also be returned.
> 
> Claims that return multiple values are represented as JSON arrays. Claims with zero elements MUST be omitted from the response.