### PR TITLE
Final refactor fixes for using keys in environment variables

### DIFF
--- a/src/ProviderController.php
+++ b/src/ProviderController.php
@@ -85,7 +85,7 @@ class ProviderController extends BaseController
             // ];
 
         } else {
-            $pkey = openssl_pkey_get_details(openssl_pkey_get_public($crypt->getKeyPath()));
+            $pkey = openssl_pkey_get_details(openssl_pkey_get_public($crypt->getKeyContents()));
         }
 
         $result['n'] = $this->base64WebSafe($pkey['rsa']['n']);

--- a/tests/UserinfoControllerTest.php
+++ b/tests/UserinfoControllerTest.php
@@ -92,8 +92,8 @@ class UserinfoControllerTest extends PassportTestCase
 
         $config = Configuration::forAsymmetricSigner(
             new Sha256(),
-            InMemory::file($keyRepository->getPrivateKey()->getKeyPath()),
-            InMemory::file($keyRepository->getPrivateKey()->getKeyPath())
+            InMemory::plainText($keyRepository->getPrivateKey()->getKeyContents()),
+            InMemory::plainText($keyRepository->getPrivateKey()->getKeyContents())
         );
 
         $token = $config->builder()


### PR DESCRIPTION
I had missed one instance of using `getKeyPath()` in `ProviderController.php` and two in `testUserinfoBasic()`.

This fixes that oversight.