### PR TITLE
Key id must match in all circumstances

### DIFF
--- a/src/KeyRepository.php
+++ b/src/KeyRepository.php
@@ -8,25 +8,31 @@ use Laravel\Passport\Passport;
 
 class KeyRepository
 {
-    public function getPrivateKey(): CryptKey
+    public function getPrivateKey(string $kid = "1"): CryptKey
     {
         $privateKey = config('passport.private_key')
             ?? 'file://' . Passport::keyPath('oauth-private.key');
-        return new CryptKey($privateKey);
+        $cryptKey = new CryptKey($privateKey);
+        $cryptKey->setKid($kid);
+        return $cryptKey;
     }
 
-    public function getPublicKey(): CryptKey
+    public function getPublicKey(string $kid = "1"): CryptKey
     {
         $publicKey = config('passport.public_key')
             ?? 'file://' . Passport::keyPath('oauth-public.key');
-        return new CryptKey($publicKey);
+        $cryptKey = new CryptKey($publicKey);
+        $cryptKey->setKid($kid);
+        return $cryptKey;
     }
 
-    public function getPublicKeyForClient(Client $client, $kid = null): CryptKey
+    public function getPublicKeyForClient(Client $client, string $kid = "1"): CryptKey
     {
         $publicKey = config('passport.public_key')
             ?? file_get_contents('file://' . Passport::keyPath('oauth-public.key'));
-        return new CryptKey($publicKey);
+        $cryptKey = new CryptKey($publicKey);
+        $cryptKey->setKid($kid);
+        return $cryptKey;
     }
 
     public function getAllPublicKeys()

--- a/src/ProviderController.php
+++ b/src/ProviderController.php
@@ -66,7 +66,7 @@ class ProviderController extends BaseController
             'alg' => 'RS256',
             'kty' => 'RSA',
             'use' => 'sig',
-            'kid' => $crypt->kid ?? 1
+            'kid' => $crypt->kid,
         ];
 
         if (!empty($crypt->x509)) {


### PR DESCRIPTION
Previously, the `jwks()` function in `ProviderController.php` would return a default kid value if the `$crypt->kid` value was null. This could be seen in the output of `.well-known/jwks.json` which would return

```json
{"keys":
[{"alg":"RS256","kty":"RSA","use":"sig","kid":1,"n":"abced..."
}]}
```

This had two problems. Firstly, the `kid` needs a string value, not a numeric. Secondly, the user token issued by the `POST` `/oauth/token` route would have a `kid` value of `null`. Therefore, no clients could match the key needed to decode the JWT.

This fix allows for the `kid` to be set via the `KeyRepository` methods if necessary, and by default sets a default string `kid` value for the returned `CryptKey` object.